### PR TITLE
switch to non reflect/generics slices.Sort() for 56% speed improvement

### DIFF
--- a/sets.go
+++ b/sets.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"golang.org/x/exp/constraints"
+	"golang.org/x/exp/slices"
 )
 
 // Set defines a low memory footprint set of any comparable type. Based on `map[T]struct{}`.
@@ -222,6 +223,6 @@ func (s *Set[T]) UnmarshalJSON(data []byte) error {
 // Only applicable for when the type is sortable.
 func Sort[Q constraints.Ordered](s Set[Q]) []Q {
 	keys := s.Elements()
-	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	slices.Sort(keys)
 	return keys
 }

--- a/sets_test.go
+++ b/sets_test.go
@@ -5,6 +5,7 @@ package sets_test
 
 import (
 	"encoding/json"
+	"math/rand"
 	"testing"
 
 	"fortio.org/assert"
@@ -170,4 +171,34 @@ func TestBadJson(t *testing.T) {
 	s := sets.New[int]()
 	err := json.Unmarshal([]byte(jsonStr), &s)
 	assert.Error(t, err)
+}
+
+func setup(b *testing.B, n int) sets.Set[int64] {
+	s := sets.Set[int64]{}
+	max := 8 * int64(n)
+	i := 0
+	for ; len(s) != n; i++ {
+		// Add random elements to the set.
+		s.Add(rand.Int63n(max)) // set is somewhat sparse
+	}
+	b.Logf("Took %d iterations to fill set", i)
+	return s
+}
+
+var s1000 sets.Set[int64]
+
+func BenchmarkSetSort1000(b *testing.B) {
+	if s1000 == nil {
+		s1000 = setup(b, 1000)
+		b.ResetTimer()
+	}
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		s1 := s1000.Clone()
+		b.StartTimer()
+		r := sets.Sort(s1)
+		if len(r) != s1.Len() {
+			b.Fatalf("unexpected length change: %d", len(r))
+		}
+	}
 }


### PR DESCRIPTION
switch to non reflect/generics slices.Sort() for 56% speed improvement in sets.Sort
```
// sort.Slices (reflect) - before
BenchmarkSetSort1000-10        16862         70937 ns/op        8248 B/op          3 allocs/op
// slices.Sort - after
BenchmarkSetSort1000-10        26198         45288 ns/op        8192 B/op          1 allocs/op
```